### PR TITLE
Added rotation parsing

### DIFF
--- a/VoxReader.UnitTests/Matrix3Tests.cs
+++ b/VoxReader.UnitTests/Matrix3Tests.cs
@@ -1,0 +1,82 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace VoxReader.UnitTests
+{
+    public class Matrix3Tests
+    {
+        [Fact]
+        public void TestIdentity()
+        {
+            Vector3 v = new Vector3(12, 3, -23);
+            (Matrix3.Identity * v).Should().Be(v);
+        }
+
+        [Fact]
+        public void TestMatrixMultMatrix()
+        {
+            var a = new Matrix3();
+            var b = new Matrix3();
+
+            a[0, 0] = 2;
+            a[0, 1] = 5;
+            a[0, 2] = -7;
+            a[1, 0] = -3;
+            a[1, 1] = -5;
+            a[1, 2] = 6;
+            a[2, 0] = 0;
+            a[2, 1] = 3;
+            a[2, 2] = 2;
+
+            b[0, 0] = 5;
+            b[0, 1] = 5;
+            b[0, 2] = 5;
+            b[1, 0] = 6;
+            b[1, 1] = -2;
+            b[1, 2] = -3;
+            b[2, 0] = 2;
+            b[2, 1] = -3;
+            b[2, 2] = -2;
+
+            var r = new Matrix3();
+            r[0, 0] = 26;
+            r[0, 1] = 21;
+            r[0, 2] = 9;
+            r[1, 0] = -33;
+            r[1, 1] = -23;
+            r[1, 2] = -12;
+            r[2, 0] = 22;
+            r[2, 1] = -12;
+            r[2, 2] = -13;
+
+
+            (a * b).Should().Be(r);
+        }
+
+        [Fact]
+        public void TestMatrixMultVector()
+        {
+            var a = new Matrix3();
+            var b = new Vector3(4, -2, 1);
+
+            a[0, 0] = 6;
+            a[0, 1] = 2;
+            a[0, 2] = 4;
+            a[1, 0] = -1;
+            a[1, 1] = 4;
+            a[1, 2] = 3;
+            a[2, 0] = -2;
+            a[2, 1] = 9;
+            a[2, 2] = 3;
+
+            var r = new Vector3(24, -9, -23);
+
+            (a * b).Should().Be(r);
+        }
+    }
+}

--- a/VoxReader.UnitTests/RotationTests.cs
+++ b/VoxReader.UnitTests/RotationTests.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VoxReader.Interfaces;
+using Xunit;
+
+namespace VoxReader.UnitTests
+{
+    public class RotationTests
+    {
+        private const string RotationTestFile = "data/rotation.zip";
+
+        [Fact]
+        public void TestApplyingRotationVoxA()
+        {
+            string file = Zip.UnzipFilesFromSevenZipArchive(RotationTestFile).First();
+            IVoxFile voxFile = VoxReader.Read(file);
+
+            var voxa = voxFile.Models.First(m => m.Name == "voxa");
+            voxa.LocalRotation.Should().Be(new Matrix3(0b0010_0001));
+            voxa.GlobalRotation.Should().Be(Matrix3.Identity);
+            voxa.LocalPosition.Should().Be(new Vector3(-4, 0, 0));
+            voxa.GlobalPosition.Should().Be(new Vector3(4, -4, 2));
+            voxa.LocalSize.Should().Be(new Vector3(5, 4, 4));
+            voxa.GlobalSize.Should().Be(new Vector3(5, 4, 4));
+
+            Vector3 min = voxa.GlobalPosition - voxa.GlobalSize / 2;
+            Vector3 max = min + voxa.GlobalSize;
+            // global position should all be in global bounds
+            foreach (var v in voxa.Voxels)
+            {
+                var k = v.GlobalPosition;
+                k.Should().Match<Vector3>(k =>
+                    k.X >= min.X && k.X < max.X &&
+                    k.Y >= min.Y && k.Y < max.Y &&
+                    k.Z >= min.Z && k.Z < max.Z);
+            }
+
+            voxa.Voxels.First(voxel => voxel.LocalPosition == new Vector3(0, 0, 0)).ColorIndex.Should().Be(215);
+            voxa.Voxels.First(voxel => voxel.GlobalPosition == new Vector3(2, -6, 0)).ColorIndex.Should().Be(215);
+        }
+
+        [Fact]
+        public void TestApplyingRotationVoxB()
+        {
+            string file = Zip.UnzipFilesFromSevenZipArchive(RotationTestFile).First();
+            IVoxFile voxFile = VoxReader.Read(file);
+
+            var voxb = voxFile.Models.First(m => m.Name == "voxb");
+            voxb.LocalRotation.Should().Be(Matrix3.Identity);
+            voxb.GlobalRotation.Should().Be(new Matrix3(0b0001_0001));
+            voxb.LocalPosition.Should().Be(new Vector3(5, 0, 0));
+            voxb.GlobalPosition.Should().Be(new Vector3(4, 5, 2));
+            voxb.LocalSize.Should().Be(new Vector3(4, 4, 4));
+            voxb.GlobalSize.Should().Be(new Vector3(4, 4, 4));
+
+            Vector3 min = voxb.GlobalPosition - voxb.GlobalSize / 2;
+            Vector3 max = min + voxb.GlobalSize;
+            // global position should all be in global bounds
+            foreach (var v in voxb.Voxels)
+            {
+                var k = v.GlobalPosition;
+                k.Should().Match<Vector3>(k =>
+                    k.X >= min.X && k.X < max.X &&
+                    k.Y >= min.Y && k.Y < max.Y &&
+                    k.Z >= min.Z && k.Z < max.Z);
+            }
+
+            voxb.Voxels.First(voxel => voxel.LocalPosition == new Vector3(0, 0, 0)).ColorIndex.Should().Be(215);
+            voxb.Voxels.First(voxel => voxel.GlobalPosition == new Vector3(5, 3, 0)).ColorIndex.Should().Be(215);
+        }
+    }
+}

--- a/VoxReader.UnitTests/UnitTests.cs
+++ b/VoxReader.UnitTests/UnitTests.cs
@@ -223,11 +223,11 @@ namespace VoxReader.UnitTests
 
             IVoxFile voxFile = VoxReader.Read(file);
 
-            voxFile.Models.Single(m => m.Name == "obj1").Position.Should().Be(new Vector3(0, 0, 0));
-            voxFile.Models.Single(m => m.Name == "obj2").Position.Should().Be(new Vector3(0, 0, 2));
-            voxFile.Models.Single(m => m.Name == "obj3").Position.Should().Be(new Vector3(-2, 1, 4));
-            voxFile.Models.Single(m => m.Name == "obj4").Position.Should().Be(new Vector3(-2, 1, 8));
-            voxFile.Models.Single(m => m.Name == "obj5").Position.Should().Be(new Vector3(2, 1, 8));
+            voxFile.Models.Single(m => m.Name == "obj1").GlobalPosition.Should().Be(new Vector3(0, 0, 0));
+            voxFile.Models.Single(m => m.Name == "obj2").GlobalPosition.Should().Be(new Vector3(0, 0, 2));
+            voxFile.Models.Single(m => m.Name == "obj3").GlobalPosition.Should().Be(new Vector3(-2, 1, 4));
+            voxFile.Models.Single(m => m.Name == "obj4").GlobalPosition.Should().Be(new Vector3(-2, 1, 8));
+            voxFile.Models.Single(m => m.Name == "obj5").GlobalPosition.Should().Be(new Vector3(2, 1, 8));
         }
 
         [Fact]
@@ -237,13 +237,13 @@ namespace VoxReader.UnitTests
 
             IVoxFile voxFile = VoxReader.Read(file);
 
-            voxFile.Models.Single(m => m.Name == "black").Position.Should().Be(new Vector3(0, 0, 0));
-            voxFile.Models.Single(m => m.Name == "red").Position.Should().Be(new Vector3(2, 0, 0));
-            voxFile.Models.Single(m => m.Name == "green").Position.Should().Be(new Vector3(0, 2, 0));
-            voxFile.Models.Single(m => m.Name == "blue").Position.Should().Be(new Vector3(0, 0, 2));
-            voxFile.Models.Single(m => m.Name == "yellow").Position.Should().Be(new Vector3(0, 0, -2));
-            voxFile.Models.Single(m => m.Name == "magenta").Position.Should().Be(new Vector3(0, -2, 0));
-            voxFile.Models.Single(m => m.Name == "cyan").Position.Should().Be(new Vector3(-2, 0, 0));
+            voxFile.Models.Single(m => m.Name == "black").GlobalPosition.Should().Be(new Vector3(0, 0, 0));
+            voxFile.Models.Single(m => m.Name == "red").GlobalPosition.Should().Be(new Vector3(2, 0, 0));
+            voxFile.Models.Single(m => m.Name == "green").GlobalPosition.Should().Be(new Vector3(0, 2, 0));
+            voxFile.Models.Single(m => m.Name == "blue").GlobalPosition.Should().Be(new Vector3(0, 0, 2));
+            voxFile.Models.Single(m => m.Name == "yellow").GlobalPosition.Should().Be(new Vector3(0, 0, -2));
+            voxFile.Models.Single(m => m.Name == "magenta").GlobalPosition.Should().Be(new Vector3(0, -2, 0));
+            voxFile.Models.Single(m => m.Name == "cyan").GlobalPosition.Should().Be(new Vector3(-2, 0, 0));
         }
 
         [Fact]
@@ -253,7 +253,7 @@ namespace VoxReader.UnitTests
 
             IVoxFile voxFile = VoxReader.Read(file);
 
-            voxFile.Models.Single(m => m.Name == "obj1").Position.Should().Be(new Vector3(1, 1, 1));
+            voxFile.Models.Single(m => m.Name == "obj1").GlobalPosition.Should().Be(new Vector3(1, 1, 1));
         }
 
         [Theory]

--- a/VoxReader.UnitTests/data/rotation.zip
+++ b/VoxReader.UnitTests/data/rotation.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:324ab9cb3ea04e7c009685be614c8de7ee3085e1ca5137f000a9ed853ef17da8
+size 2734

--- a/VoxReader/Chunks/TransformNodeChunk.cs
+++ b/VoxReader/Chunks/TransformNodeChunk.cs
@@ -33,7 +33,7 @@ namespace VoxReader.Chunks
             {
                 var frameDictionary = FormatParser.ParseDictionary();
 
-                byte frameRotation = 0;
+                byte frameRotation = 0b0000_0100;
                 if (frameDictionary.TryGetValue("_r", out string r))
                     frameRotation = byte.Parse(r);
 
@@ -46,7 +46,7 @@ namespace VoxReader.Chunks
 
                 Frames[i] = new Frame
                 {
-                    Rotation = frameRotation,
+                    Rotation = new Matrix3(frameRotation),
                     Translation = frameTranslation
                 };
             }

--- a/VoxReader/Frame.cs
+++ b/VoxReader/Frame.cs
@@ -2,7 +2,7 @@
 {
     public struct Frame
     {
-        public byte Rotation;
+        public Matrix3 Rotation;
         public Vector3 Translation;
     }
 }

--- a/VoxReader/Helper.cs
+++ b/VoxReader/Helper.cs
@@ -74,7 +74,6 @@ namespace VoxReader
                 foreach (int id in ids)
                 {
                     string name = transformNodeChunk.Name;
-                    // -> global size
                     Vector3 localSize = sizeChunks[id].Size;
                     Vector3 globalPos = GetGlobalTranslation(transformNodeChunk);
                     Matrix3 globalRotation = GetGlobalRotation(transformNodeChunk);

--- a/VoxReader/Helper.cs
+++ b/VoxReader/Helper.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using VoxReader.Exceptions;
 using VoxReader.Interfaces;
@@ -56,7 +58,7 @@ namespace VoxReader
             {
                 Vector3 size = sizeChunks[0].Size;
                 var voxels = voxelChunks[0].Voxels.Select(voxel => new Voxel(voxel.Position, voxel.Position, palette.RawColors[voxel.ColorIndex - 1], inverseIndexMap[voxel.ColorIndex - 1])).ToArray();
-                yield return new Model(0, null, new Vector3(), Matrix3.Identity, size, voxels, false);
+                yield return new Model(0, null, voxels, false, new Vector3(), new Vector3(), Matrix3.Identity, Matrix3.Identity, size);
                 yield break;
             }
 
@@ -72,14 +74,26 @@ namespace VoxReader
                 foreach (int id in ids)
                 {
                     string name = transformNodeChunk.Name;
-                    Vector3 size = sizeChunks[id].Size;
-                    Vector3 translation = GetGlobalTranslation(transformNodeChunk);
-                    Matrix3 rotation = GetGlobalRotation(transformNodeChunk);
+                    // -> global size
+                    Vector3 localSize = sizeChunks[id].Size;
+                    Vector3 globalPos = GetGlobalTranslation(transformNodeChunk);
+                    Matrix3 globalRotation = GetGlobalRotation(transformNodeChunk);
 
-                    var voxels = voxelChunks[id].Voxels.Select(voxel => new Voxel(voxel.Position, translation + voxel.Position - size / 2, palette.RawColors[voxel.ColorIndex - 1], inverseIndexMap[voxel.ColorIndex - 1])).ToArray();
+                    var voxels = voxelChunks[id].Voxels.Select(voxel =>
+                    {
+                        return new Voxel(
+                            voxel.Position,
+                            ApplyTransformationToVoxel(voxel.Position, globalPos, globalRotation, localSize),
+                            palette.RawColors[voxel.ColorIndex - 1], inverseIndexMap[voxel.ColorIndex - 1]);
+                    }).ToArray();
 
                     // Create new model
-                    var model = new Model(id, name, translation, rotation, size, voxels, !processedModelIds.Add(id));
+                    var model = new Model(id, name, voxels, !processedModelIds.Add(id),
+                        globalPos,
+                        transformNodeChunk.Frames[0].Translation,
+                        globalRotation,
+                        transformNodeChunk.Frames[0].Rotation,
+                        sizeChunks[id].Size);
                     yield return model;
                 }
             }
@@ -87,11 +101,9 @@ namespace VoxReader
             Vector3 GetGlobalTranslation(ITransformNodeChunk target)
             {
                 Vector3 position = target.Frames[0].Translation;
-
                 while (TryGetParentTransformNodeChunk(target, out ITransformNodeChunk parent))
                 {
-                    position += parent.Frames[0].Translation;
-
+                    position = parent.Frames[0].Rotation * position + parent.Frames[0].Translation;
                     target = parent;
                 }
 
@@ -101,15 +113,18 @@ namespace VoxReader
             Matrix3 GetGlobalRotation(ITransformNodeChunk target)
             {
                 Matrix3 rotation = target.Frames[0].Rotation;
-
                 while (TryGetParentTransformNodeChunk(target, out ITransformNodeChunk parent))
                 {
-                    rotation *= parent.Frames[0].Rotation;
-
+                    rotation = parent.Frames[0].Rotation * rotation;
                     target = parent;
                 }
 
                 return rotation;
+            }
+
+            Vector3 ApplyTransformationToVoxel(Vector3 voxelPos, Vector3 globalPivot, Matrix3 globalRot, Vector3 size)
+            {
+                return globalPivot + globalRot.RotateIndex(voxelPos - size / 2);
             }
 
             bool TryGetParentTransformNodeChunk(ITransformNodeChunk target, out ITransformNodeChunk parent)

--- a/VoxReader/Interfaces/IModel.cs
+++ b/VoxReader/Interfaces/IModel.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace VoxReader.Interfaces
 {
     public interface IModel
@@ -6,17 +8,46 @@ namespace VoxReader.Interfaces
         /// The name of the model.
         /// </summary>
         string Name { get; }
-        
-        /// <summary>
-        /// The position of the model.
-        /// </summary>
+
+        [Obsolete("Use LocalPosition instead.")]
         Vector3 Position { get; }
-        
-        /// <summary>
-        /// The size of the model.
-        /// </summary>
+
+        [Obsolete("Use LocalSize instead.")]
         Vector3 Size { get; }
-        
+
+        /// <summary>
+        /// The global position of the model in the world.
+        /// </summary>
+        Vector3 GlobalPosition { get; }
+
+        /// <summary>
+        /// The position of the model relative to it's parent.
+        /// </summary>
+        Vector3 LocalPosition { get; }
+
+        /// <summary>
+        /// The global rotation of the model in the world. Includes rotations of all parents.
+        /// </summary>
+        Matrix3 GlobalRotation { get; }
+
+        /// <summary>
+        /// The rotation of the model relative to it's parent.
+        /// </summary>
+        Matrix3 LocalRotation { get; }
+
+        /// <summary>
+        /// The global size of the model. In magicavoxel models don't have a scale factor, but rotations can swap side lengths.
+        /// <see cref="LocalSize"/> and <see cref="GlobalSize"/> will always have the same volume, but may be differently rotated from each other. 
+        /// </summary>
+        Vector3 GlobalSize { get; }
+
+
+        /// <summary>
+        /// The local size of the model. In magicavoxel models don't have a scale factor, but rotations can swap side lengths.
+        /// <see cref="LocalSize"/> and <see cref="GlobalSize"/> will always have the same volume, but may be differently rotated from each other. 
+        /// </summary>
+        Vector3 LocalSize { get; }
+
         /// <summary>
         /// All voxels that belong to the model.
         /// </summary>

--- a/VoxReader/Matrix3.cs
+++ b/VoxReader/Matrix3.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VoxReader
+{
+    public class Matrix3 : IEquatable<Matrix3>
+    {
+        public static Matrix3 Identity => new Matrix3(0b0000_0100);
+
+        private static readonly int[] Row2Lookup = new int[] { int.MaxValue, int.MaxValue, int.MaxValue, 2, int.MaxValue, 1, 0, int.MaxValue };
+
+
+        public int this[int row, int column]
+        {
+            get => m[row, column];
+            set => m[row, column] = value;
+        }
+
+        readonly int[,] m = new int[3, 3];
+
+        public Matrix3(byte data)
+        {
+            int row0Index = data & 0b11;
+            int row1Index = (data >> 2) & 0b11;
+            int row2Index = Row2Lookup[(1 << row0Index) | (1 << row1Index)];
+            if (row2Index == int.MaxValue)
+                throw new ArgumentException("Invalid roation bytes");
+
+            int sign0 = (data >> 4) & 1;
+            int sign1 = (data >> 5) & 1;
+            int sign2 = (data >> 6) & 1;
+
+            m = new int[3, 3];
+            m[0, row0Index] = sign0 == 0 ? 1 : -1;
+            m[1, row1Index] = sign1 == 0 ? 1 : -1;
+            m[2, row2Index] = sign2 == 0 ? 1 : -1;
+        }
+
+        public Matrix3()
+        {
+
+        }
+
+        public static Matrix3 operator *(Matrix3 a, Matrix3 b)
+        {
+            Matrix3 result = new Matrix3();
+            result[0, 0] = a[0, 0] * b[0, 0] + a[0, 1] * b[1, 0] + a[0, 2] * b[2, 0];
+            result[0, 1] = a[0, 0] * b[0, 1] + a[0, 1] * b[1, 1] + a[0, 2] * b[2, 1];
+            result[0, 2] = a[0, 0] * b[0, 2] + a[0, 1] * b[1, 2] + a[0, 2] * b[2, 2];
+
+            result[1, 0] = a[1, 0] * b[0, 0] + a[1, 1] * b[1, 0] + a[1, 2] * b[2, 0];
+            result[1, 1] = a[1, 0] * b[0, 1] + a[1, 1] * b[1, 1] + a[1, 2] * b[2, 1];
+            result[1, 2] = a[1, 0] * b[0, 2] + a[1, 1] * b[1, 2] + a[1, 2] * b[2, 2];
+
+            result[2, 0] = a[2, 0] * b[0, 0] + a[2, 1] * b[1, 0] + a[2, 2] * b[2, 0];
+            result[2, 1] = a[2, 0] * b[0, 1] + a[2, 1] * b[1, 1] + a[2, 2] * b[2, 1];
+            result[2, 2] = a[2, 0] * b[0, 2] + a[2, 1] * b[1, 2] + a[2, 2] * b[2, 2];
+
+            return result;
+        }
+
+        public static Vector3 operator *(Matrix3 a, Vector3 b)
+        {
+            return new Vector3(
+                a[0, 0] * b.X + a[0, 1] * b.Y + a[0, 2] * b.Z,
+                a[1, 0] * b.X + a[1, 1] * b.Y + a[1, 2] * b.Z,
+                a[2, 0] * b.X + a[2, 1] * b.Y + a[2, 2] * b.Z);
+        }
+
+        public bool Equals(Matrix3 other)
+        {
+            if (other == null)
+                return false;
+
+            for(int i = 0; i < 3; i++)
+            {
+                for(int j = 0; j < 3; j++)
+                {
+                    if (this[i, j] != other[i, j])
+                        return false;
+                }
+            }
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return $"(({this[0, 0]}, {this[0, 1]}, {this[0, 2]})\n" +
+                   $"({this[1, 0]}, {this[1, 1]}, {this[1, 2]})\n" +
+                   $"({this[2, 0]}, {this[2, 1]}, {this[2, 2]}))";
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Matrix3);
+        }
+    }
+}

--- a/VoxReader/Matrix3.cs
+++ b/VoxReader/Matrix3.cs
@@ -68,14 +68,31 @@ namespace VoxReader
                 a[2, 0] * b.X + a[2, 1] * b.Y + a[2, 2] * b.Z);
         }
 
+        public Vector3 RotateIndex(Vector3 b)
+        {
+            float offsetX = b.X + 0.5f;
+            float offsetY = b.Y + 0.5f;
+            float offsetZ = b.Z + 0.5f;
+
+            float valX = this[0, 0] * offsetX + this[0, 1] * offsetY + this[0, 2] * offsetZ;
+            float valY = this[1, 0] * offsetX + this[1, 1] * offsetY + this[1, 2] * offsetZ;
+            float valZ = this[2, 0] * offsetX + this[2, 1] * offsetY + this[2, 2] * offsetZ;
+
+            return new Vector3(
+                (int)Math.Floor(valX),
+                (int)Math.Floor(valY),
+                (int)Math.Floor(valZ));
+        }
+
+
         public bool Equals(Matrix3 other)
         {
             if (other == null)
                 return false;
 
-            for(int i = 0; i < 3; i++)
+            for (int i = 0; i < 3; i++)
             {
-                for(int j = 0; j < 3; j++)
+                for (int j = 0; j < 3; j++)
                 {
                     if (this[i, j] != other[i, j])
                         return false;

--- a/VoxReader/Model.cs
+++ b/VoxReader/Model.cs
@@ -6,16 +6,18 @@ namespace VoxReader
     {
         public string Name { get; }
         public Vector3 Position { get; }
+        public Matrix3 Rotation { get; }
         public Vector3 Size { get; }
         public Voxel[] Voxels { get; }
         public int Id { get; }
         public bool IsCopy { get; }
 
-        public Model(int id, string name, Vector3 position, Vector3 size, Voxel[] voxels, bool isCopy)
+        public Model(int id, string name, Vector3 position, Matrix3 rotation, Vector3 size, Voxel[] voxels, bool isCopy)
         {
             Id = id;
             Name = name;
             Position = position;
+            Rotation = rotation;
             Size = size;
             Voxels = voxels;
             IsCopy = isCopy;
@@ -23,12 +25,12 @@ namespace VoxReader
 
         internal Model GetCopy()
         {
-            return new(Id, Name, Position, Size, Voxels, true);
+            return new(Id, Name, Position, Rotation, Size, Voxels, true);
         }
         
         public override string ToString()
         {
-            return $"Id: {Id}, Name: {Name}, Position: {Position}, Size: {Size}, Voxel Count: {Voxels.Length}";
+            return $"Id: {Id}, Name: {Name}, Position: {Position}, Rotation: {Rotation}, Size: {Size}, Voxel Count: {Voxels.Length}";
         }
     }
 }

--- a/VoxReader/Model.cs
+++ b/VoxReader/Model.cs
@@ -5,32 +5,43 @@ namespace VoxReader
     public class Model : IModel
     {
         public string Name { get; }
-        public Vector3 Position { get; }
-        public Matrix3 Rotation { get; }
-        public Vector3 Size { get; }
+        public Vector3 GlobalPosition { get; }
+        public Vector3 LocalPosition { get; }
+        public Matrix3 GlobalRotation { get; }
+        public Matrix3 LocalRotation { get; }
+        public Vector3 GlobalSize => (GlobalRotation * LocalSize).ToAbsolute();
+        public Vector3 LocalSize { get; }
         public Voxel[] Voxels { get; }
         public int Id { get; }
         public bool IsCopy { get; }
 
-        public Model(int id, string name, Vector3 position, Matrix3 rotation, Vector3 size, Voxel[] voxels, bool isCopy)
+        public Vector3 Position => LocalPosition;
+        public Vector3 Size => LocalSize;
+
+        public Model(int id, string name, Voxel[] voxels, bool isCopy, Vector3 position, Vector3 localPosition, Matrix3 rotation, Matrix3 localRotation, Vector3 localSize)
         {
             Id = id;
             Name = name;
-            Position = position;
-            Rotation = rotation;
-            Size = size;
             Voxels = voxels;
             IsCopy = isCopy;
+
+            GlobalPosition = position;
+            LocalPosition = localPosition;
+
+            GlobalRotation = rotation;
+            LocalRotation = localRotation;
+
+            LocalSize = localSize;
         }
 
         internal Model GetCopy()
         {
-            return new(Id, Name, Position, Rotation, Size, Voxels, true);
+            return new(Id, Name, Voxels, true, GlobalPosition, LocalPosition, GlobalRotation, LocalRotation, LocalSize);
         }
         
         public override string ToString()
         {
-            return $"Id: {Id}, Name: {Name}, Position: {Position}, Rotation: {Rotation}, Size: {Size}, Voxel Count: {Voxels.Length}";
+            return $"Id: {Id}, Name: {Name}, GPosition: {GlobalPosition}, GRotation: {GlobalRotation}, GSize: {GlobalSize}, Voxel Count: {Voxels.Length}";
         }
     }
 }

--- a/VoxReader/Vector3.cs
+++ b/VoxReader/Vector3.cs
@@ -52,6 +52,11 @@ namespace VoxReader
             }
         }
 
+        public Vector3 ToAbsolute()
+        {
+            return new Vector3(Math.Abs(X), Math.Abs(Y), Math.Abs(Z));
+        }
+
         //TODO: add unit tests
 
         public static bool operator ==(Vector3 a, Vector3 b)

--- a/VoxReader/Voxel.cs
+++ b/VoxReader/Voxel.cs
@@ -1,12 +1,17 @@
+using System;
+
 namespace VoxReader
 {
     public readonly struct Voxel
     {
+        [Obsolete("Use localposition instead.")]
+        public Vector3 Position => LocalPosition;
+
         /// <summary>
         /// The position of the voxel in the model.
         /// </summary>
-        public Vector3 Position { get; }
-        
+        public Vector3 LocalPosition { get; }
+
         /// <summary>
         /// The global position of the voxel in the scene.
         /// </summary>
@@ -22,9 +27,9 @@ namespace VoxReader
         /// </summary>
         public int ColorIndex { get; }
 
-        internal Voxel(Vector3 position, Vector3 globalPosition, Color color, int mappedColorIndex)
+        internal Voxel(Vector3 localPosition, Vector3 globalPosition, Color color, int mappedColorIndex)
         {
-            Position = position;
+            LocalPosition = localPosition;
             GlobalPosition = globalPosition;
             Color = color;
             ColorIndex = mappedColorIndex;
@@ -32,7 +37,7 @@ namespace VoxReader
 
         public override string ToString()
         {
-            return $"Position: [{Position}], Color: [{Color}]";
+            return $"LPosition: [{LocalPosition}], Color: [{Color}]";
         }
     }
 }


### PR DESCRIPTION
Implemented parsing the rotation value so that users of this library can read it alongside the position of a model.
Didn't want to apply the rotation directly to the voxel position yet, as that is a breaking change. Maybe that should be mentioned somewhere?

Would be nice to have a new nuget package with this change published, as I am using this library in a personal project that requires rotation to be read.